### PR TITLE
Fix Auth Flow - Dialog should be shown during first encryption

### DIFF
--- a/surelock/src/main/java/com/smashingboxes/surelock/Surelock.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/Surelock.java
@@ -216,6 +216,15 @@ public class Surelock {
         enrollFingerprintAndStore(key, fragment, fragmentManager, fingerprintDialogFragmentTag);
     }
 
+    /**
+     * Enroll a fingerprint, encrypt a value, and store the value at the specified key
+     * Use this if you want to use your own custom dialog rather than Surelock's default dialog
+     *
+     * @param key pointer in storage to encrypted value
+     * @param surelockFragment your own custom Surelock Fragment
+     * @param fragmentManager FragmentManger used to load the dialog fragment
+     * @param fingerprintDialogFragmentTag tag associated with the dialog fragment
+     */
     public void enrollFingerprintAndStore(String key,
                                           SurelockFragment surelockFragment,
                                           @NonNull FragmentManager fragmentManager,

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
@@ -220,6 +220,7 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
+        outState.putByteArray(KEY_VALUE_TO_ENCRYPT, valueToEncrypt);
         outState.putInt(KEY_STYLE_ID, styleId);
         super.onSaveInstanceState(outState);
     }

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockFingerprintListener.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockFingerprintListener.java
@@ -12,6 +12,11 @@ import android.support.annotation.Nullable;
 public interface SurelockFingerprintListener {
 
     /**
+     * Handle successful fingerprint enrollment event
+     */
+    void onFingerprintEnrolled();
+
+    /**
      * Handle successful authentication event
      *
      * @param decryptedValue String which represents the decrypted bytes of the store value


### PR DESCRIPTION
## Why?
According to the [Material Design Specifications on fingerprint enrollment](https://material.io/guidelines/patterns/fingerprint.html#fingerprint-enrollment), we should always show a fingerprint dialog even when the user is first enrolling their fingerprint for authentication.

It's not actually necessary for encryption, so it's currently working such that there is no initial fingerprint dialog when signing in for the first time.
We should fix this.

## What Changed?
- Added a new callback in our FingerprintListener interface which the developer's LoginActivity will have to implement.
- Updated Surelock and SurelockDefaultDialog to handle encryption/decryption based on a cipher operation mode.
- Had to switch back to Symmetric encryption as the default. TODO: we need to get asymmetric working again.
- Updated LoginActivity in our demo module for the correct auth flow according to the Material Design specs.