### PR TITLE
Update default styles

### DIFF
--- a/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
+++ b/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
@@ -104,7 +104,7 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
                 fingerprintCheckbox.setVisibility(View.VISIBLE);
                 fingerprintCheckbox.setChecked(false);
             } else {
-                surelock.loginWithFingerprint(KEY_CRE_DEN_TIALS, getFragmentManager(), FINGERPRINT_DIALOG_FRAGMENT_TAG, 0);
+                surelock.loginWithFingerprint(KEY_CRE_DEN_TIALS, getFragmentManager(), FINGERPRINT_DIALOG_FRAGMENT_TAG, R.style.SurelockDemoDialog);
                 fingerprintCheckbox.setVisibility(View.GONE);
             }
         }

--- a/demo/src/main/res/values/styles.xml
+++ b/demo/src/main/res/values/styles.xml
@@ -8,6 +8,9 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="android:navigationBarColor" tools:targetApi="21">@color/colorPrimary</item>
+
+        <item name="swirl_ridgeColor">@android:color/black</item>
+        <item name="swirl_errorColor">@color/error_red</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
@@ -18,5 +21,10 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
+
+    <style name="SurelockDemoDialog">
+        <item name="sl_fallback_button_text">@string/password</item>
+        <item name="sl_dialog_theme">@style/AppTheme</item>
+    </style>
 
 </resources>

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
@@ -114,8 +114,8 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
         int dialogTheme = attrs.getResourceId(R.styleable.SurelockDefaultDialog_sl_dialog_theme, 0);
         attrs.recycle();
 
-        setStyle(DialogFragment.STYLE_NO_TITLE, dialogTheme == 0 ? android.R.style.Theme :
-                dialogTheme);
+        setStyle(DialogFragment.STYLE_NO_TITLE, dialogTheme == 0 ? R.style
+                .SurelockTheme_NoActionBar : dialogTheme);
     }
 
     @Override

--- a/surelock/src/main/res/values/styles.xml
+++ b/surelock/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="SurelockTheme" parent="Theme.AppCompat.Dialog.Alert">
+    <style name="SurelockTheme" parent="Theme.AppCompat">
         <item name="swirl_ridgeColor">@android:color/black</item>
         <item name="swirl_errorColor">@color/error_red</item>
         <item name="android:textColorPrimary">@color/primary_text</item>


### PR DESCRIPTION
Why?
-The default dialog style wasn't showing the fingerprint icon and some of the associated text

What?
-Instead of using `android.R.style.Theme` for the default dialog style, we should use `R.style.SurelockTheme_NoActionBar` since it includes the correct text and fingerprint icon colors
-Updated `R.style.SurelockTheme_NoActionBar`'s parent to be just `Theme.AppCompat`. This way the dialog fragment will take up the whole screen
-Added a style for the dialog in the demo app so that the bottom text and colors match the other screens. This meant that the swirl colors also needed to go into the demo app's style