### PR TITLE
Properly handle keystore key invalidation

### DIFF
--- a/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
+++ b/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
@@ -25,6 +25,7 @@ import android.widget.Toast;
 import com.smashingboxes.surelock.SharedPreferencesStorage;
 import com.smashingboxes.surelock.Surelock;
 import com.smashingboxes.surelock.SurelockFingerprintListener;
+import com.smashingboxes.surelock.SurelockInvalidKeyException;
 import com.smashingboxes.surelock.SurelockStorage;
 
 import java.io.UnsupportedEncodingException;
@@ -104,7 +105,11 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
                 fingerprintCheckbox.setVisibility(View.VISIBLE);
                 fingerprintCheckbox.setChecked(false);
             } else {
-                surelock.loginWithFingerprint(KEY_CRE_DEN_TIALS, getFragmentManager(), FINGERPRINT_DIALOG_FRAGMENT_TAG, R.style.SurelockDemoDialog);
+                try {
+                    surelock.loginWithFingerprint(KEY_CRE_DEN_TIALS, getFragmentManager(), FINGERPRINT_DIALOG_FRAGMENT_TAG, R.style.SurelockDemoDialog);
+                } catch (SurelockInvalidKeyException e) {
+                    //TODO show a dialog telling user to re-enter their credentials because their fingerprints have changed.
+                }
                 fingerprintCheckbox.setVisibility(View.GONE);
             }
         }

--- a/surelock/src/main/java/com/smashingboxes/surelock/Surelock.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/Surelock.java
@@ -432,13 +432,14 @@ public class Surelock {
                 try {
                     if (encryptionType == ASYMMETRIC) {
                         getCipherInstance().init(Cipher.DECRYPT_MODE, secretKey);
+                        return;
                     } else {
                         byte[] encryptionIv = getEncryptionIv();
                         if (encryptionIv != null) {
                             getCipherInstance().init(Cipher.DECRYPT_MODE, secretKey, new IvParameterSpec(encryptionIv));
+                            return;
                         }
                     }
-                    return;
                 } catch (KeyPermanentlyInvalidatedException e) {
                     Log.d(TAG, "Keys were invalidated. Creating new key...");
                 }

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockInvalidKeyException.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockInvalidKeyException.java
@@ -1,0 +1,17 @@
+package com.smashingboxes.surelock;
+
+/**
+ * Created by Tyler McCraw on 4/3/17.
+ * <p>
+ *     KeyStore key was invalidated. This means you need to re-enroll the fingerprint
+ *     via enrollFingerprintAndStore() or store() methods so that the value
+ *     can be re-encrypted with a valid key.
+ * </p>
+ */
+
+public class SurelockInvalidKeyException extends SurelockException {
+
+    public SurelockInvalidKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Why?
It's possible for users to have their keystore key invalidated due to additional fingerprints added, fingerprints changed, fingerprints removed, or fingerprint settings turned off. All of these events trigger Android to invalidate keystore keys that were previously generated with saved fingerprints.
We need to properly throw an exception when this happens so that developers can show a hard error message (preferably in a dialog) to the users to let them know that they must re-sign in with their credentials to re-enroll a fingerprint. Developers should also clear the SurelockStorage when this happens!

## What Changed?
- Exposed a new SurelockKeyInvalidatedException to the developers who use Surelock.
- Updated example code to catch this exception (although, we need to add in some code for showing an AlertDialog).