### PR TITLE
Add builder pattern - first pass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 

--- a/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
+++ b/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
@@ -107,7 +107,7 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
                 fingerprintCheckbox.setChecked(false);
             } else {
                 try {
-                    getSurelock().loginWithFingerprint();
+                    getSurelock().loginWithFingerprint(KEY_CRE_DEN_TIALS);
                 } catch (SurelockInvalidKeyException e) {
                     surelockStorage.clearAll();
                     showFingerprintLoginInvalidated();
@@ -122,7 +122,6 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
             surelock = new Surelock.Builder(this)
                     .withDefaultDialog(R.style.SurelockDemoDialog)
                     .withKeystoreAlias(KEYSTORE_KEY_ALIAS)
-                    .withKey(KEY_CRE_DEN_TIALS)
                     .withFragmentManager(getFragmentManager())
                     .withSurelockFragmentTag(FINGERPRINT_DIALOG_FRAGMENT_TAG)
                     .withSurelockStorage(surelockStorage)
@@ -294,8 +293,8 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
             showProgress(false);
             if (withFingerprintEnrollment) {
                 try {
-                    getSurelock().enrollFingerprintAndStore(getFormattedCredentialsForEncryption
-                            (params[0], params[1]));
+                    getSurelock().enrollFingerprintAndStore(KEY_CRE_DEN_TIALS,
+                            getFormattedCredentialsForEncryption(params[0], params[1]));
                 } catch (UnsupportedEncodingException e) {
                     Toast.makeText(LoginActivity.this, "Failed to encrypt the login", Toast.LENGTH_LONG).show();
                     Log.e(TAG, "Failed to encrypt the login" + e.getMessage());

--- a/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
+++ b/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.java
@@ -49,9 +49,9 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
     private static final String SHARED_PREFS_FILE_NAME = "surelock_demo_prefs";
 
     private UserLoginTask authTask = null;
+    private Surelock surelock;
     private SurelockStorage surelockStorage;
     private SharedPreferences preferences;
-    private Surelock.SurelockDialogBuilder builder;
 
     private TextInputEditText usernameView;
     private TextInputLayout usernameInputLayout;
@@ -107,8 +107,7 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
                 fingerprintCheckbox.setChecked(false);
             } else {
                 try {
-                    setUpBuilder();
-                    builder.loginWithFingerprint(this);
+                    getSurelock().loginWithFingerprint();
                 } catch (SurelockInvalidKeyException e) {
                     surelockStorage.clearAll();
                     showFingerprintLoginInvalidated();
@@ -118,14 +117,18 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
         }
     }
 
-    private void setUpBuilder() {
-        if (builder == null) {
-            builder = new Surelock.SurelockDialogBuilder
-                    (KEY_CRE_DEN_TIALS, getFragmentManager(), FINGERPRINT_DIALOG_FRAGMENT_TAG);
-            builder.withDefaultDialog(R.style.SurelockDemoDialog)
+    private Surelock getSurelock() {
+        if (surelock == null) {
+            surelock = new Surelock.Builder(this)
+                    .withDefaultDialog(R.style.SurelockDemoDialog)
                     .withKeystoreAlias(KEYSTORE_KEY_ALIAS)
-                    .withSurelockStorage(surelockStorage);
+                    .withKey(KEY_CRE_DEN_TIALS)
+                    .withFragmentManager(getFragmentManager())
+                    .withSurelockFragmentTag(FINGERPRINT_DIALOG_FRAGMENT_TAG)
+                    .withSurelockStorage(surelockStorage)
+                    .build();
         }
+        return surelock;
     }
 
     private void showFingerprintLoginInvalidated() {
@@ -291,9 +294,8 @@ public class LoginActivity extends AppCompatActivity implements SurelockFingerpr
             showProgress(false);
             if (withFingerprintEnrollment) {
                 try {
-                    setUpBuilder();
-                    builder.enrollFingerprintAndStore(LoginActivity.this,
-                                    getFormattedCredentialsForEncryption(params[0], params[1]));
+                    getSurelock().enrollFingerprintAndStore(getFormattedCredentialsForEncryption
+                            (params[0], params[1]));
                 } catch (UnsupportedEncodingException e) {
                     Toast.makeText(LoginActivity.this, "Failed to encrypt the login", Toast.LENGTH_LONG).show();
                     Log.e(TAG, "Failed to encrypt the login" + e.getMessage());

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
@@ -33,7 +33,6 @@ import javax.crypto.IllegalBlockSizeException;
 public class SurelockDefaultDialog extends DialogFragment implements SurelockFragment {
 
     private static final String KEY_CIPHER_OP_MODE = "com.smashingboxes.surelock.SurelockDefaultDialog.KEY_CIPHER_OP_MODE";
-    private static final String KEY_VALUE_TO_ENCRYPT = "com.smashingboxes.surelock.SurelockDefaultDialog.KEY_VALUE_TO_ENCRYPT";
     private static final String KEY_STYLE_ID = "com.smashingboxes.surelock.KEY_STYLE_ID";
 
     private static final long ERROR_TIMEOUT_MILLIS = 1600;
@@ -54,24 +53,10 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     private SwirlView iconView;
     private TextView statusTextView;
 
-    public static SurelockDefaultDialog newInstance(int cipherOperationMode,
+    static SurelockDefaultDialog newInstance(int cipherOperationMode,
                                                     @StyleRes int styleId) {
         Bundle args = new Bundle();
         args.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
-        args.putInt(KEY_STYLE_ID, styleId);
-
-        SurelockDefaultDialog fragment = new SurelockDefaultDialog();
-        fragment.setArguments(args);
-
-        return fragment;
-    }
-
-    public static SurelockDefaultDialog newInstance(int cipherOperationMode,
-                                                    @NonNull byte[] valueToEncrypt,
-                                                    @StyleRes int styleId) {
-        Bundle args = new Bundle();
-        args.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
-        args.putByteArray(KEY_VALUE_TO_ENCRYPT, valueToEncrypt);
         args.putInt(KEY_STYLE_ID, styleId);
 
         SurelockDefaultDialog fragment = new SurelockDefaultDialog();
@@ -83,11 +68,12 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     @Override
     public void init(FingerprintManager fingerprintManager,
                      FingerprintManager.CryptoObject cryptoObject,
-                     @NonNull String key, SurelockStorage storage) {
+                     @NonNull String key, SurelockStorage storage, byte[] valueToEncrypt) {
         this.cryptoObject = cryptoObject;
         this.fingerprintManager = fingerprintManager;
         this.keyForDecryption = key; //TODO need to be passing these as newInstance params... or figure a better way to do this
         this.storage = storage;
+        this.valueToEncrypt = valueToEncrypt;
     }
 
     @Override
@@ -101,11 +87,9 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
 
         if (savedInstanceState != null) {
             cipherOperationMode = savedInstanceState.getInt(KEY_CIPHER_OP_MODE);
-            valueToEncrypt = savedInstanceState.getByteArray(KEY_VALUE_TO_ENCRYPT);
             styleId = savedInstanceState.getInt(KEY_STYLE_ID);
         } else {
             cipherOperationMode = getArguments().getInt(KEY_CIPHER_OP_MODE);
-            valueToEncrypt = getArguments().getByteArray(KEY_VALUE_TO_ENCRYPT);
             styleId = getArguments().getInt(KEY_STYLE_ID);
         }
 
@@ -220,7 +204,6 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
-        outState.putByteArray(KEY_VALUE_TO_ENCRYPT, valueToEncrypt);
         outState.putInt(KEY_STYLE_ID, styleId);
         super.onSaveInstanceState(outState);
     }

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockFragment.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockFragment.java
@@ -3,6 +3,7 @@ package com.smashingboxes.surelock;
 import android.app.FragmentManager;
 import android.hardware.fingerprint.FingerprintManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * Created by Tyler McCraw on 2/17/17.
@@ -23,9 +24,10 @@ public interface SurelockFragment {
      * @param cryptoObject the CryptoObject which wraps the cipher used for encryption/decryption
      * @param key pointer in storage to encrypted value that will be used for this session's decryption
      * @param storage instance of SurelockStorage to be used for decrypting the value at the specified key
+     * @param valueToEncrypt The value to encrypt in storage
      */
     void init(FingerprintManager fingerprintManager, FingerprintManager.CryptoObject cryptoObject,
-              @NonNull String key, SurelockStorage storage);
+              @NonNull String key, SurelockStorage storage, @Nullable byte[] valueToEncrypt);
 
     /**
      * Display the fragment

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockMaterialDialog.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockMaterialDialog.java
@@ -32,8 +32,6 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
 
     private static final String KEY_CIPHER_OP_MODE = "com.smashingboxes.surelock" +
             ".SurelockMaterialDialog.KEY_CIPHER_OP_MODE";
-    private static final String KEY_VALUE_TO_ENCRYPT = "com.smashingboxes.surelock" +
-            ".SurelockMaterialDialog.KEY_VALUE_TO_ENCRYPT";
 
     private SwirlView swirlView;
     private TextView messageView;
@@ -50,22 +48,10 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
     private static final long ERROR_TIMEOUT_MILLIS = 1600;
     private static final long SUCCESS_DELAY_MILLIS = 1300;
 
-    public static SurelockMaterialDialog newInstance(int cipherOperationMode) {
+    static SurelockMaterialDialog newInstance(int cipherOperationMode) {
 
         Bundle args = new Bundle();
         args.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
-
-        SurelockMaterialDialog fragment = new SurelockMaterialDialog();
-        fragment.setArguments(args);
-        return fragment;
-    }
-
-    public static SurelockMaterialDialog newInstance(int cipherOperationMode, @NonNull byte[]
-            valueToEncrypt) {
-
-        Bundle args = new Bundle();
-        args.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
-        args.putByteArray(KEY_VALUE_TO_ENCRYPT, valueToEncrypt);
 
         SurelockMaterialDialog fragment = new SurelockMaterialDialog();
         fragment.setArguments(args);
@@ -94,10 +80,8 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
 
         if (savedInstanceState != null) {
             cipherOperationMode = savedInstanceState.getInt(KEY_CIPHER_OP_MODE);
-            valueToEncrypt = savedInstanceState.getByteArray(KEY_VALUE_TO_ENCRYPT);
         } else {
             cipherOperationMode = getArguments().getInt(KEY_CIPHER_OP_MODE);
-            valueToEncrypt = getArguments().getByteArray(KEY_VALUE_TO_ENCRYPT);
         }
 
         setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
@@ -150,17 +134,17 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putInt(KEY_CIPHER_OP_MODE, cipherOperationMode);
-        outState.putByteArray(KEY_VALUE_TO_ENCRYPT, valueToEncrypt);
         super.onSaveInstanceState(outState);
     }
 
     @Override
     public void init(FingerprintManager fingerprintManager, FingerprintManager.CryptoObject
-            cryptoObject, @NonNull String key, SurelockStorage storage) {
+            cryptoObject, @NonNull String key, SurelockStorage storage, byte[] valueToEncrypt) {
         this.fingerprintManager = fingerprintManager;
         this.cryptoObject = cryptoObject;
         this.keyForDecryption = key;
         this.storage = storage;
+        this.valueToEncrypt = valueToEncrypt;
     }
 
     @Override

--- a/surelock/src/main/res/values/strings.xml
+++ b/surelock/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="error_toast_user_enable_securelock">Secure lock screen hasn\'t been set up.\n Go to \'Settings -> Security -> Fingerprint\' to set up a fingerprint</string>
     <string name="error_toast_user_enroll_fingerprints">Go to \'Settings -> Security -> Fingerprint\' and register at least one fingerprint</string>
     <string name="sl_sign_in">Sign in</string>
+    <string name="sl_login_error">Fingerprint Login Error</string>
+    <string name="sl_re_enroll">The fingerprints enrolled on this device have changed. Please re-enter your credentials to enable fingerprint login.</string>
 </resources>


### PR DESCRIPTION
## Why?
-We should add a builder pattern to Surelock to make initializing the dialogs and running enrollment/login more straightforward

## What?
-Added a new builder class to Surelock to handle getting all the properties necessary for fingerprint login (I'm open to any feedback on this pattern)
-Used builder in the demo login activity
-Also added logic to show an AlertDialog when a `SurelockInvalidKeyException` is thrown and the user needs to re-enroll