### PR TITLE
Replace API level check

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.smashingboxes.surelock_demo"
-        minSdkVersion 23
+        minSdkVersion 15
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    compile 'com.android.support:design:25.2.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:design:25.3.1'
     compile project(path: ':surelock')
 }

--- a/surelock/build.gradle
+++ b/surelock/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '25.0.1'
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 15
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -18,6 +18,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.mattprecious.swirl:swirl:1.0.0'
 }

--- a/surelock/src/main/java/com/smashingboxes/surelock/Surelock.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/Surelock.java
@@ -5,7 +5,6 @@ import android.app.FragmentManager;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.hardware.fingerprint.FingerprintManager;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
@@ -14,6 +13,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
+import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
@@ -81,7 +81,7 @@ public class Surelock {
 
 
     private SurelockFingerprintListener listener;
-    private FingerprintManager fingerprintManager;
+    private FingerprintManagerCompat fingerprintManager;
     private KeyStore keyStore;
     private KeyGenerator keyGenerator;
     private KeyPairGenerator keyPairGenerator;
@@ -98,9 +98,6 @@ public class Surelock {
     private int styleId;
 
     static Surelock initialize(@NonNull Builder builder) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return null;
-        }
         return new Surelock(builder);
     }
 
@@ -126,7 +123,7 @@ public class Surelock {
             Log.e(TAG, "Failed to set up KeyStore", e);
         }
 
-        fingerprintManager = builder.context.getSystemService(FingerprintManager.class);
+        fingerprintManager = FingerprintManagerCompat.from(builder.context);
     }
 
     /**
@@ -136,7 +133,7 @@ public class Surelock {
      */
     @SuppressWarnings({"MissingPermission"})
     public static boolean hasFingerprintHardware(Context context) {
-        return context.getSystemService(FingerprintManager.class).isHardwareDetected();
+        return FingerprintManagerCompat.from(context).isHardwareDetected();
     }
 
     /**
@@ -146,7 +143,7 @@ public class Surelock {
      */
     @SuppressWarnings({"MissingPermission"})
     public static boolean hasUserEnrolledFingerprints(Context context) {
-        return context.getSystemService(FingerprintManager.class).hasEnrolledFingerprints();
+        return FingerprintManagerCompat.from(context).hasEnrolledFingerprints();
     }
 
     /**
@@ -169,9 +166,6 @@ public class Surelock {
      * @return true if user has fingerprint hardware, has enabled secure lock, and has enrolled fingerprints
      */
     public static boolean fingerprintAuthIsSetUp(Context context, boolean showMessaging) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return false;
-        }
         if (!hasFingerprintHardware(context)) {
             return false;
         }
@@ -285,7 +279,7 @@ public class Surelock {
 
     private void showFingerprintDialog(String key, @NonNull Cipher cipher, SurelockFragment
             surelockFragment, @Nullable byte[] valueToEncrypt) {
-        surelockFragment.init(fingerprintManager, new FingerprintManager.CryptoObject(cipher),
+        surelockFragment.init(fingerprintManager, new FingerprintManagerCompat.CryptoObject(cipher),
                 key, storage, valueToEncrypt);
         surelockFragment.show(fragmentManager, surelockFragmentTag);
     }

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.java
@@ -5,10 +5,11 @@ import android.app.DialogFragment;
 import android.app.FragmentManager;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.hardware.fingerprint.FingerprintManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StyleRes;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,8 +39,8 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     private static final long ERROR_TIMEOUT_MILLIS = 1600;
     private static final long SUCCESS_DELAY_MILLIS = 1300; //TODO make these configurable via attrs
 
-    private FingerprintManager fingerprintManager;
-    private FingerprintManager.CryptoObject cryptoObject;
+    private FingerprintManagerCompat fingerprintManager;
+    private FingerprintManagerCompat.CryptoObject cryptoObject;
     private String keyForDecryption;
     private byte[] valueToEncrypt;
     private SurelockStorage storage;
@@ -66,8 +67,8 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     }
 
     @Override
-    public void init(FingerprintManager fingerprintManager,
-                     FingerprintManager.CryptoObject cryptoObject,
+    public void init(FingerprintManagerCompat fingerprintManager,
+                     FingerprintManagerCompat.CryptoObject cryptoObject,
                      @NonNull String key, SurelockStorage storage, byte[] valueToEncrypt) {
         this.cryptoObject = cryptoObject;
         this.fingerprintManager = fingerprintManager;
@@ -209,7 +210,7 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     }
 
     @Override
-    public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
+    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
         iconView.postDelayed(new Runnable() {
             @Override
             public void run() {
@@ -259,7 +260,7 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
     private void showError(CharSequence error) {
         iconView.setState(SwirlView.State.ERROR);
         statusTextView.setText(error);
-        statusTextView.setTextColor(getResources().getColor(R.color.error_red, null));
+        statusTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.error_red));
         statusTextView.removeCallbacks(resetErrorTextRunnable);
         statusTextView.postDelayed(resetErrorTextRunnable, ERROR_TIMEOUT_MILLIS);
     }
@@ -268,7 +269,7 @@ public class SurelockDefaultDialog extends DialogFragment implements SurelockFra
         @Override
         public void run() {
             if (isAdded()) {
-                statusTextView.setTextColor(getResources().getColor(R.color.hint_grey, null));
+                statusTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.hint_grey));
                 statusTextView.setText(getResources().getString(R.string.fingerprint_hint));
                 iconView.setState(SwirlView.State.ON);
             }

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockFingerprintUiHelper.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockFingerprintUiHelper.java
@@ -1,7 +1,7 @@
 package com.smashingboxes.surelock;
 
-import android.hardware.fingerprint.FingerprintManager;
-import android.os.CancellationSignal;
+import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
+import android.support.v4.os.CancellationSignal;
 
 /**
  * Created by Tyler McCraw on 2/17/17.
@@ -11,26 +11,26 @@ import android.os.CancellationSignal;
  * </p>
  */
 
-public class SurelockFingerprintUiHelper extends FingerprintManager.AuthenticationCallback {
+public class SurelockFingerprintUiHelper extends FingerprintManagerCompat.AuthenticationCallback {
 
-    private final FingerprintManager fingerprintManager;
+    private final FingerprintManagerCompat fingerprintManager;
     private final SurelockFragment callback;
     private CancellationSignal cancellationSignal;
     private boolean selfCancelled;
 
-    SurelockFingerprintUiHelper(FingerprintManager fingerprintManager, SurelockFragment callback) {
+    SurelockFingerprintUiHelper(FingerprintManagerCompat fingerprintManager, SurelockFragment callback) {
         this.fingerprintManager = fingerprintManager;
         this.callback = callback;
     }
 
-    public void startListening(FingerprintManager.CryptoObject cryptoObject) {
+    public void startListening(FingerprintManagerCompat.CryptoObject cryptoObject) {
         cancellationSignal = new CancellationSignal();
         selfCancelled = false;
 
         //TODO pass in a handler here for background authentication?
         //TODO take a look at per-user FingerprintManager.authenticate(..., userId) call
         // noinspection ResourceType
-        fingerprintManager.authenticate(cryptoObject, cancellationSignal, 0 /* flags */, this, null);
+        fingerprintManager.authenticate(cryptoObject, 0 /* flags */, cancellationSignal, this, null);
     }
 
     public void stopListening() {
@@ -59,7 +59,7 @@ public class SurelockFingerprintUiHelper extends FingerprintManager.Authenticati
     }
 
     @Override
-    public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
+    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
         callback.onAuthenticationSucceeded(result);
     }
 }

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockFragment.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockFragment.java
@@ -1,9 +1,9 @@
 package com.smashingboxes.surelock;
 
 import android.app.FragmentManager;
-import android.hardware.fingerprint.FingerprintManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 
 /**
  * Created by Tyler McCraw on 2/17/17.
@@ -26,8 +26,9 @@ public interface SurelockFragment {
      * @param storage instance of SurelockStorage to be used for decrypting the value at the specified key
      * @param valueToEncrypt The value to encrypt in storage
      */
-    void init(FingerprintManager fingerprintManager, FingerprintManager.CryptoObject cryptoObject,
-              @NonNull String key, SurelockStorage storage, @Nullable byte[] valueToEncrypt);
+    void init(FingerprintManagerCompat fingerprintManager, FingerprintManagerCompat.CryptoObject
+            cryptoObject, @NonNull String key, SurelockStorage storage, @Nullable byte[]
+            valueToEncrypt);
 
     /**
      * Display the fragment
@@ -63,7 +64,7 @@ public interface SurelockFragment {
      *
      * @param result An object containing authentication-related data
      */
-    void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result);
+    void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result);
 
     /**
      * Called when a fingerprint is valid but not recognized.

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockMaterialDialog.java
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockMaterialDialog.java
@@ -3,10 +3,11 @@ package com.smashingboxes.surelock;
 import android.app.DialogFragment;
 import android.app.FragmentManager;
 import android.content.Context;
-import android.hardware.fingerprint.FingerprintManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -36,8 +37,8 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
     private SwirlView swirlView;
     private TextView messageView;
 
-    private FingerprintManager fingerprintManager;
-    private FingerprintManager.CryptoObject cryptoObject;
+    private FingerprintManagerCompat fingerprintManager;
+    private FingerprintManagerCompat.CryptoObject cryptoObject;
     private String keyForDecryption;
     private byte[] valueToEncrypt;
     private SurelockStorage storage;
@@ -138,7 +139,7 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
     }
 
     @Override
-    public void init(FingerprintManager fingerprintManager, FingerprintManager.CryptoObject
+    public void init(FingerprintManagerCompat fingerprintManager, FingerprintManagerCompat.CryptoObject
             cryptoObject, @NonNull String key, SurelockStorage storage, byte[] valueToEncrypt) {
         this.fingerprintManager = fingerprintManager;
         this.cryptoObject = cryptoObject;
@@ -161,7 +162,7 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
     }
 
     @Override
-    public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
+    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
         swirlView.postDelayed(new Runnable() {
             @Override
             public void run() {
@@ -200,7 +201,7 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
     private void showError(CharSequence error) {
         swirlView.setState(SwirlView.State.ERROR);
         messageView.setText(error);
-        messageView.setTextColor(getResources().getColor(R.color.error_red, null));
+        messageView.setTextColor(ContextCompat.getColor(getActivity(), R.color.error_red));
         messageView.removeCallbacks(resetErrorTextRunnable);
         messageView.postDelayed(resetErrorTextRunnable, ERROR_TIMEOUT_MILLIS);
     }
@@ -209,7 +210,7 @@ public class SurelockMaterialDialog extends DialogFragment implements SurelockFr
         @Override
         public void run() {
             if (isAdded()) {
-                messageView.setTextColor(getResources().getColor(R.color.hint_grey, null));
+                messageView.setTextColor(ContextCompat.getColor(getActivity(), R.color.hint_grey));
                 messageView.setText(getResources().getString(R.string.fingerprint_hint));
                 swirlView.setState(SwirlView.State.ON);
             }


### PR DESCRIPTION
## Why?
-Previously, users would have to check the API level to see if it was 23 or above before using Surelock's features. See issue [here](https://github.com/smashingboxes/surelock/issues/10).

## What?
-Replaced occurrences of `FingerprintManager` with `FingerprintManagerCompat` for backwards compatibility so users no longer have to check API level
-Replaced calls to `getColor()` with equivalent `ContextCompat` calls
-Bumped the minSdkVersion down to 15 (minimum supported by the [Swirl library](https://github.com/mattprecious/swirl/blob/master/swirl/src/main/AndroidManifest.xml))