### PR TITLE
Remove references to native fragment

### DIFF
--- a/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.kt
+++ b/demo/src/main/java/com/smashingboxes/surelockdemo/LoginActivity.kt
@@ -36,7 +36,7 @@ class LoginActivity : AppCompatActivity(), SurelockFingerprintListener {
         Surelock.Builder(this)
             .withDefaultDialog(R.style.SurelockDemoDialog)
             .withKeystoreAlias(KEYSTORE_KEY_ALIAS)
-            .withFragmentManager(fragmentManager)
+            .withFragmentManager(supportFragmentManager)
             .withSurelockFragmentTag(FINGERPRINT_DIALOG_FRAGMENT_TAG)
             .withSurelockStorage(surelockStorage)
             .build()
@@ -288,10 +288,10 @@ class LoginActivity : AppCompatActivity(), SurelockFingerprintListener {
     companion object {
 
         private val TAG = LoginActivity::class.java.simpleName
-        private val FINGERPRINT_DIALOG_FRAGMENT_TAG = "com.smashingboxes.surelockdemo.FINGERPRINT_DIALOG_FRAGMENT_TAG"
-        private val KEYSTORE_KEY_ALIAS = "com.smashingboxes.surelockdemo.KEYSTORE_KEY_ALIAS"
-        private val KEY_CRE_DEN_TIALS = "com.smashingboxes.surelockdemo.KEY_CRE_DEN_TIALS"
-        private val SHARED_PREFS_FILE_NAME = "surelock_demo_prefs"
-        private val DELIMITER = "%s]%s"
+        private const val FINGERPRINT_DIALOG_FRAGMENT_TAG = "com.smashingboxes.surelockdemo.FINGERPRINT_DIALOG_FRAGMENT_TAG"
+        private const val KEYSTORE_KEY_ALIAS = "com.smashingboxes.surelockdemo.KEYSTORE_KEY_ALIAS"
+        private const val KEY_CRE_DEN_TIALS = "com.smashingboxes.surelockdemo.KEY_CRE_DEN_TIALS"
+        private const val SHARED_PREFS_FILE_NAME = "surelock_demo_prefs"
+        private const val DELIMITER = "%s]%s"
     }
 }

--- a/surelock/src/main/java/com/smashingboxes/surelock/Surelock.kt
+++ b/surelock/src/main/java/com/smashingboxes/surelock/Surelock.kt
@@ -1,7 +1,6 @@
 package com.smashingboxes.surelock
 
 import android.annotation.TargetApi
-import android.app.FragmentManager
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
@@ -11,6 +10,7 @@ import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import android.support.annotation.IntDef
 import android.support.annotation.StyleRes
+import android.support.v4.app.FragmentManager
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat
 import android.util.Log
 import android.widget.Toast

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.kt
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockDefaultDialog.kt
@@ -1,12 +1,12 @@
 package com.smashingboxes.surelock
 
 import android.app.Dialog
-import android.app.DialogFragment
-import android.app.FragmentManager
 import android.content.Context
 import android.content.res.TypedArray
 import android.os.Bundle
 import android.support.annotation.StyleRes
+import android.support.v4.app.DialogFragment
+import android.support.v4.app.FragmentManager
 import android.support.v4.content.ContextCompat
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat
 import android.view.LayoutInflater
@@ -45,16 +45,16 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
     private var styleId: Int = 0
 
     // TODO  clean up and genericize default dialog - add custom attribute set which can be overridden
-    private var iconView: SwirlView? = null
-    private var statusTextView: TextView? = null
+    private lateinit var iconView: SwirlView
+    private lateinit var statusTextView: TextView
 
     private val resetErrorTextRunnable = Runnable {
         if (isAdded) {
-            statusTextView?.apply {
-                setTextColor(ContextCompat.getColor(activity, R.color.hint_grey))
-                text = resources.getString(R.string.fingerprint_hint)
+            statusTextView.apply {
+                setTextColor(ContextCompat.getColor(context, R.color.hint_grey))
+                text = getString(R.string.fingerprint_hint)
             }
-            iconView?.setState(SwirlView.State.ON)
+            iconView.setState(SwirlView.State.ON)
         }
     }
 
@@ -80,11 +80,11 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
             cipherOperationMode = savedInstanceState.getInt(KEY_CIPHER_OP_MODE)
             styleId = savedInstanceState.getInt(KEY_STYLE_ID)
         } else {
-            cipherOperationMode = arguments.getInt(KEY_CIPHER_OP_MODE)
-            styleId = arguments.getInt(KEY_STYLE_ID)
+            cipherOperationMode = arguments!!.getInt(KEY_CIPHER_OP_MODE)
+            styleId = arguments!!.getInt(KEY_STYLE_ID)
         }
 
-        val attrs = activity.obtainStyledAttributes(styleId, R.styleable
+        val attrs = context!!.obtainStyledAttributes(styleId, R.styleable
             .SurelockDefaultDialog)
         val dialogTheme = attrs.getResourceId(R.styleable.SurelockDefaultDialog_sl_dialog_theme, 0)
         attrs.recycle()
@@ -96,7 +96,7 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fingerprint_dialog_container, container, false)
-        val attrs = activity.obtainStyledAttributes(styleId, R.styleable.SurelockDefaultDialog)
+        val attrs = activity!!.obtainStyledAttributes(styleId, R.styleable.SurelockDefaultDialog)
 
         setUpViews(view, attrs)
 
@@ -160,7 +160,7 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
     override fun onResume() {
         super.onResume()
         uiHelper?.startListening(cryptoObject!!)
-        iconView?.setState(SwirlView.State.ON)
+        iconView.setState(SwirlView.State.ON)
     }
 
     override fun show(fragmentManager: FragmentManager, fingerprintDialogFragmentTag: String) {
@@ -186,35 +186,35 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
     }
 
     override fun onAuthenticationSucceeded(result: FingerprintManagerCompat.AuthenticationResult?) {
-        iconView?.postDelayed({
+        iconView.postDelayed({
             //TODO figure out a way to not make user have to run encryption/decryption themselves here
             if (Cipher.ENCRYPT_MODE == cipherOperationMode) {
                 try {
                     val encryptedValue = cryptoObject?.cipher?.doFinal(valueToEncrypt)
                     keyForDecryption?.let {
-                        if (encryptedValue != null) {
-                            storage?.createOrUpdate(it, encryptedValue)
-                            listener?.onFingerprintEnrolled()
-                        }
+                        storage?.createOrUpdate(it, encryptedValue!!)
+                        listener?.onFingerprintEnrolled()
                     }
                 } catch (e: IllegalBlockSizeException) {
                     listener?.onFingerprintError(e.message)
                 } catch (e: BadPaddingException) {
                     listener?.onFingerprintError(e.message)
+                } catch (e: NullPointerException) {
+                    listener?.onFingerprintError(e.message)
                 }
-
             } else if (Cipher.DECRYPT_MODE == cipherOperationMode) {
                 val encryptedValue = storage?.get(keyForDecryption!!)
-                val decryptedValue: ByteArray
+                val decryptedValue: ByteArray?
                 try {
-                    decryptedValue = cryptoObject?.cipher?.doFinal(encryptedValue) ?: ByteArray(0)
-                    listener?.onFingerprintAuthenticated(decryptedValue)
+                    decryptedValue = cryptoObject?.cipher?.doFinal(encryptedValue)
+                    listener?.onFingerprintAuthenticated(decryptedValue!!)
                 } catch (e: BadPaddingException) {
                     listener?.onFingerprintError(e.message)
                 } catch (e: IllegalBlockSizeException) {
                     listener?.onFingerprintError(e.message)
+                } catch (e: NullPointerException) {
+                    listener?.onFingerprintError(e.message)
                 }
-
             }
             dismiss()
         }, SUCCESS_DELAY_MILLIS)
@@ -232,15 +232,15 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
     }
 
     override fun onAuthenticationFailed() {
-        showError(statusTextView!!.resources.getString(R.string.fingerprint_not_recognized))
+        showError(getString(R.string.fingerprint_not_recognized))
         listener?.onFingerprintError(null)
     }
 
     private fun showError(error: CharSequence?) {
-        iconView?.setState(SwirlView.State.ERROR)
-        statusTextView?.apply {
+        iconView.setState(SwirlView.State.ERROR)
+        statusTextView.apply {
             text = error
-            setTextColor(ContextCompat.getColor(activity, R.color.error_red))
+            setTextColor(ContextCompat.getColor(context, R.color.error_red))
             removeCallbacks(resetErrorTextRunnable)
             postDelayed(resetErrorTextRunnable, ERROR_TIMEOUT_MILLIS)
         }
@@ -248,11 +248,11 @@ class SurelockDefaultDialog : DialogFragment(), SurelockFragment {
 
     companion object {
 
-        private val KEY_CIPHER_OP_MODE = "com.smashingboxes.surelock.SurelockDefaultDialog.KEY_CIPHER_OP_MODE"
-        private val KEY_STYLE_ID = "com.smashingboxes.surelock.KEY_STYLE_ID"
+        private const val KEY_CIPHER_OP_MODE = "com.smashingboxes.surelock.SurelockDefaultDialog.KEY_CIPHER_OP_MODE"
+        private const val KEY_STYLE_ID = "com.smashingboxes.surelock.KEY_STYLE_ID"
 
-        private val ERROR_TIMEOUT_MILLIS: Long = 1600
-        private val SUCCESS_DELAY_MILLIS: Long = 1300 //TODO make these configurable via attrs
+        private const val ERROR_TIMEOUT_MILLIS: Long = 1600
+        private const val SUCCESS_DELAY_MILLIS: Long = 1300 //TODO make these configurable via attrs
 
         internal fun newInstance(cipherOperationMode: Int,
                                  @StyleRes styleId: Int): SurelockDefaultDialog {

--- a/surelock/src/main/java/com/smashingboxes/surelock/SurelockFragment.kt
+++ b/surelock/src/main/java/com/smashingboxes/surelock/SurelockFragment.kt
@@ -1,6 +1,6 @@
 package com.smashingboxes.surelock
 
-import android.app.FragmentManager
+import android.support.v4.app.FragmentManager
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat
 
 /**


### PR DESCRIPTION
## Why?
-Android will be removing support for the native fragment in Android P, so we need to remove it from Surelock

## What?
-Replaced uses of the native fragment with the support fragment
-Made some minor changes to fix errors introduced by Kotlin conversion